### PR TITLE
Correct bugs related to overlapping vertices

### DIFF
--- a/src/webgl/p5.Geometry.js
+++ b/src/webgl/p5.Geometry.js
@@ -1599,6 +1599,7 @@ p5.Geometry = class Geometry {
  * @chainable
  */
   _edgesToVertices() {
+    // probably needs to add something in here for custom attributes
     this.lineVertices.clear();
     this.lineTangentsIn.clear();
     this.lineTangentsOut.clear();

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -46,7 +46,7 @@ p5.RendererGL.prototype.beginShape = function(mode) {
   return this;
 };
 
-const immediateBufferStrides = {
+p5.RendererGL.prototype.immediateBufferStrides = {
   vertices: 1,
   vertexNormals: 1,
   vertexColors: 4,
@@ -86,8 +86,8 @@ p5.RendererGL.prototype.vertex = function(x, y) {
     // 1--2     1--2   4
     // When vertex index 3 is being added, add the necessary duplicates.
     if (this.immediateMode.geometry.vertices.length % 6 === 3) {
-      for (const key in immediateBufferStrides) {
-        const stride = immediateBufferStrides[key];
+      for (const key in this.immediateBufferStrides) {
+        const stride = this.immediateBufferStrides[key];
         const buffer = this.immediateMode.geometry[key];
         buffer.push(
           ...buffer.slice(

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -40,8 +40,10 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     delete this.userAttributes;
     this._useUserAttributes = false;
   }
-  this.tessyVertexSize = 12;
-  this.tessy = this._initTessy(this.tessyVertexSize);
+  if (this.tessyVertexSize > 12){
+    this.tessyVertexSize = 12;
+    this._updateTessyCombineCallback();
+  }
   this.immediateMode.geometry.reset();
   this.immediateMode.contourIndices = [];
   return this;
@@ -457,9 +459,6 @@ p5.RendererGL.prototype._calculateEdges = function(
  */
 p5.RendererGL.prototype._tesselateShape = function() {
   // TODO: handle non-TESS shape modes that have contours
-  if (this.tessyVertexSize > 12){
-    this._tessy = this._initTessy(this.tessyVertexSize);
-  }
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [[]];
   for (let i = 0; i < this.immediateMode.geometry.vertices.length; i++) {
@@ -494,9 +493,11 @@ p5.RendererGL.prototype._tesselateShape = function() {
       } else{
         delete this.userAttributes[attr];
         this.tessyVertexSize -= size;
-        this._tessy = this._initTessy(this.tessyVertexSize);
       }
     }
+  }
+  if (this.tessyVertexSize > 12){
+    this._updateTessyCombineCallback();
   }
   const polyTriangles = this._triangulate(contours);
   const originalVertices = this.immediateMode.geometry.vertices;

--- a/src/webgl/p5.RendererGL.Immediate.js
+++ b/src/webgl/p5.RendererGL.Immediate.js
@@ -41,6 +41,7 @@ p5.RendererGL.prototype.beginShape = function(mode) {
     this._useUserAttributes = false;
   }
   this.tessyVertexSize = 12;
+  this.tessy = this._initTessy(this.tessyVertexSize);
   this.immediateMode.geometry.reset();
   this.immediateMode.contourIndices = [];
   return this;
@@ -456,6 +457,9 @@ p5.RendererGL.prototype._calculateEdges = function(
  */
 p5.RendererGL.prototype._tesselateShape = function() {
   // TODO: handle non-TESS shape modes that have contours
+  if (this.tessyVertexSize > 12){
+    this._tessy = this._initTessy(this.tessyVertexSize);
+  }
   this.immediateMode.shapeMode = constants.TRIANGLES;
   const contours = [[]];
   for (let i = 0; i < this.immediateMode.geometry.vertices.length; i++) {
@@ -490,6 +494,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
       } else{
         delete this.userAttributes[attr];
         this.tessyVertexSize -= size;
+        this._tessy = this._initTessy(this.tessyVertexSize);
       }
     }
   }
@@ -499,7 +504,7 @@ p5.RendererGL.prototype._tesselateShape = function() {
   this.immediateMode.geometry.vertexNormals = [];
   this.immediateMode.geometry.uvs = [];
   for (const attr in this.userAttributes){
-    delete this.immediateMode.geometry[attr]
+    this.immediateMode.geometry[attr] = [];
   }
   const colors = [];
   for (

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -671,8 +671,7 @@ p5.RendererGL = class RendererGL extends Renderer {
 
     // Used to distinguish between user calls to vertex() and internal calls
     this.isProcessingVertices = false;
-    this.tessyVertexSize = 12;
-    this._tessy = this._initTessy(this.tessyVertexSize);
+    this._tessy = this._initTessy();
 
     this.fontInfos = {};
 
@@ -2418,7 +2417,7 @@ p5.RendererGL = class RendererGL extends Renderer {
     const p = [p1, p2, p3, p4];
     return p;
   }
-  _initTessy(tessyVertexSize) {
+  _initTessy() {
     // function called for each vertex of tesselator output
     function vertexCallback(data, polyVertArray) {
       for (const element of data) {
@@ -2438,7 +2437,7 @@ p5.RendererGL = class RendererGL extends Renderer {
     }
     // callback for when segments intersect and must be split
     function combinecallback(coords, data, weight) {
-      const result = new Array(tessyVertexSize).fill(0);
+      const result = new Array(p5.RendererGL.prototype.tessyVertexSize).fill(0);
       for (let i = 0; i < weight.length; i++) {
         for (let j = 0; j < result.length; j++) {
           if (weight[i] === 0 || !data[i]) continue;
@@ -2464,6 +2463,23 @@ p5.RendererGL = class RendererGL extends Renderer {
     );
 
     return tessy;
+  }
+
+  _updateTessyCombineCallback() {
+    // If custom attributes have been used, the vertex data which needs to be 
+    // combined has changed, so libtess must have its combine callback updated
+    const combinecallback = (coords, data, weight) => {
+      const result = new Array(this.tessyVertexSize).fill(0);
+      for (let i = 0; i < weight.length; i++) {
+        for (let j = 0; j < result.length; j++) {
+          if (weight[i] === 0 || !data[i]) continue;
+          result[j] += data[i][j] * weight[i];
+        }
+      }
+      return result;
+    };
+  
+    this._tessy.gluTessCallback(libtess.gluEnum.GLU_TESS_COMBINE, combinecallback);
   }
 
   _triangulate(contours) {
@@ -2527,5 +2543,9 @@ p5.prototype._assert3d = function (name) {
       `${name}() is only supported in WEBGL mode. If you'd like to use 3D graphics and WebGL, see  https://p5js.org/examples/form-3d-primitives.html for more information.`
     );
 };
+
+// Initial vertex data size for libtess
+
+p5.RendererGL.prototype.tessyVertexSize = 12;
 
 export default p5.RendererGL;

--- a/src/webgl/p5.RendererGL.js
+++ b/src/webgl/p5.RendererGL.js
@@ -671,7 +671,8 @@ p5.RendererGL = class RendererGL extends Renderer {
 
     // Used to distinguish between user calls to vertex() and internal calls
     this.isProcessingVertices = false;
-    this._tessy = this._initTessy();
+    this.tessyVertexSize = 12;
+    this._tessy = this._initTessy(this.tessyVertexSize);
 
     this.fontInfos = {};
 
@@ -2417,7 +2418,7 @@ p5.RendererGL = class RendererGL extends Renderer {
     const p = [p1, p2, p3, p4];
     return p;
   }
-  _initTessy() {
+  _initTessy(tessyVertexSize) {
     // function called for each vertex of tesselator output
     function vertexCallback(data, polyVertArray) {
       for (const element of data) {
@@ -2437,7 +2438,7 @@ p5.RendererGL = class RendererGL extends Renderer {
     }
     // callback for when segments intersect and must be split
     function combinecallback(coords, data, weight) {
-      const result = new Array(p5.RendererGL.prototype.tessyVertexSize).fill(0);
+      const result = new Array(tessyVertexSize).fill(0);
       for (let i = 0; i < weight.length; i++) {
         for (let j = 0; j < result.length; j++) {
           if (weight[i] === 0 || !data[i]) continue;
@@ -2526,9 +2527,5 @@ p5.prototype._assert3d = function (name) {
       `${name}() is only supported in WEBGL mode. If you'd like to use 3D graphics and WebGL, see  https://p5js.org/examples/form-3d-primitives.html for more information.`
     );
 };
-
-// function to initialize GLU Tesselator
-
-p5.RendererGL.prototype.tessyVertexSize = 12;
 
 export default p5.RendererGL;


### PR DESCRIPTION
The GLUTesselator / libtess implementation defines callbacks for different occasions, including where vertices overlap and must be combined. Previously, this was not including the size of custom attributes in the tessellation algorithm. 

I have also added a warning in case some user attributes array is of the wrong size, which is how I found this bug above.